### PR TITLE
fix: Dockerfile healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN bundle install --jobs=8
 ADD . /app
 
 HEALTHCHECK --interval=2s --timeout=4s --start-period=3s --retries=15 \
-  CMD curl -f "http://localhost:${PORT}" || exit 1
+  CMD curl -f "http://0.0.0.0:8080" || exit 1
 
 CMD ["bundle", "exec", "unicorn", "-c", "./config/unicorn.rb"]


### PR DESCRIPTION
Hey, sorry, looks like there was an issue with the change from #95 

Not sure why it was passing for me before, but looks like this does the trick. Would you mind ensuring that the health check works for you too?

It seems the `curl` command is run _within_ the docker container, which I hadn't realised before, so I can just point it directly to port 8080.