### PR TITLE
fix: Configure Unicorn to log to stdout

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -7,6 +7,8 @@ worker_process_count = (ENV["WORKER_PROCESSES"] || 4).to_i
 preload_app true
 worker_processes worker_process_count
 timeout 10
+stderr_path "/dev/stdout"
+stdout_path "/dev/stdout"
 
 initialized = false
 before_fork do |_server, _worker|


### PR DESCRIPTION
I'm hosting at [Railway](https://railway.com/), and they treat `stderr` output as errors. Seeing as [Unicorn's default logger sends its output to `stderr`](https://www.rubydoc.info/gems/unicorn/Unicorn/Configurator), this means every log from Frankfurter is seen as an error. 

This change redirects both `stderr` and `stdout` to `/dev/stdout` so logs display correctly without error indicators.