### PR TITLE
support for multiple sources in v2

### DIFF
--- a/db/migrate/002_create_sources.rb
+++ b/db/migrate/002_create_sources.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table :sources do
+      String  :code, size: 10, primary_key: true
+      String  :name, size: 100, null: false
+      String  :base_currency, size: 3
+    end
+  end
+
+  down do
+    drop_table :sources
+  end
+end

--- a/db/migrate/003_add_source_to_currencies.rb
+++ b/db/migrate/003_add_source_to_currencies.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table :currencies do
+      add_column :source_code, String, size: 10, default: "ECB"
+      add_foreign_key [:source_code], :sources, key: :code
+    end
+
+    drop_index :currencies, [:date, :iso_code], concurrently: true
+    add_index :currencies, [:date, :iso_code, :source_code], unique: true, concurrently: true
+  end
+
+  down do
+    alter_table :currencies do
+      drop_foreign_key [:source_code]
+      drop_column :source_code
+    end
+
+    drop_index :currencies, [:date, :iso_code, :source_code], concurrently: true
+    add_index :currencies, [:date, :iso_code], unique: true, concurrently: true
+  end
+end

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -4,6 +4,7 @@ require "rack/cors"
 require "roda"
 
 require "versions/v1"
+require "versions/v2"
 
 class App < Roda
   use Rack::Cors do
@@ -32,6 +33,10 @@ class App < Roda
   route do |r|
     r.on("v1") do
       r.run(Versions::V1)
+    end
+
+    r.on("v2") do
+      r.run(Versions::V2)
     end
   end
 end

--- a/lib/bank.rb
+++ b/lib/bank.rb
@@ -44,6 +44,7 @@ module Bank
             date: day[:date],
             iso_code: iso_code,
             rate: rate,
+            source_code: "ECB",
           }
         end
       end

--- a/lib/currency.rb
+++ b/lib/currency.rb
@@ -3,7 +3,18 @@
 require "db"
 
 class Currency < Sequel::Model
+  many_to_one :source, key: :source_code, primary_key: :code
+
+  def before_validation
+    super
+    self.source_code ||= "ECB"
+  end
+
   dataset_module do
+    def by_source(source_code)
+      where(source_code: source_code)
+    end
+
     def latest(date = Date.today)
       date = Date.today if date > Date.today
       where(date: nearest_date_with_rates(date))

--- a/lib/query.rb
+++ b/lib/query.rb
@@ -40,7 +40,21 @@ class Query
     end
   end
 
+  def source
+    @params[:source]&.upcase
+  end
+
+  def from
+    base
+  end
+
+  def to
+    symbols
+  end
+
   def to_h
-    { amount:, base:, date:, symbols: }.compact
+    result = { amount:, base:, date:, symbols: }.compact
+    result[:source] = source if @params.key?(:source)
+    result
   end
 end

--- a/lib/quote/end_of_day.rb
+++ b/lib/quote/end_of_day.rb
@@ -1,23 +1,24 @@
 # frozen_string_literal: true
 
 require "quote/base"
-require "digest"
 
 module Quote
   class EndOfDay < Base
     def formatted
-      {
+      result_hash = {
         amount:,
         base:,
         date: result.keys.first,
         rates: result.values.first,
       }
+      result_hash[:source] = source if source
+      result_hash.compact
     end
 
     def cache_key
       return if not_found?
 
-      Digest::MD5.hexdigest(result.keys.first)
+      "#{result.keys.first}-#{source}"
     end
 
     private
@@ -26,8 +27,8 @@ module Quote
       require "currency"
 
       scope = Currency.latest(date)
+      scope = scope.by_source(source) if source
       scope = scope.only(*(symbols + [base])) if symbols
-
       scope.naked
     end
   end

--- a/lib/quote/interval.rb
+++ b/lib/quote/interval.rb
@@ -5,19 +5,21 @@ require "quote/base"
 module Quote
   class Interval < Base
     def formatted
-      {
+      result_hash = {
         amount:,
         base:,
         start_date: result.keys.first,
         end_date: result.keys.last,
         rates: result,
       }
+      result_hash[:source] = source if source
+      result_hash.compact
     end
 
     def cache_key
       return if not_found?
 
-      Digest::MD5.hexdigest(result.keys.last)
+      "#{result.keys.first}_#{result.keys.last}-#{source}"
     end
 
     private
@@ -26,8 +28,8 @@ module Quote
       require "currency"
 
       scope = Currency.between(date)
+      scope = scope.by_source(source) if source
       scope = scope.only(*(symbols + [base])) if symbols
-
       scope.naked
     end
   end

--- a/lib/source.rb
+++ b/lib/source.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "db"
+
+class Source < Sequel::Model
+  one_to_many :currencies, key: :source_code, primary_key: :code
+
+  def validate
+    super
+    validates_presence([:code, :name])
+    validates_unique(:code)
+    validates_format(/^[A-Z]{2,10}$/, :code)
+  end
+end

--- a/lib/tasks/sources.rake
+++ b/lib/tasks/sources.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "../../boot"
+
+namespace :db do
+  desc "Seed sources"
+  task :seed_sources do
+    require "source"
+
+    sources_data = [
+      {
+        code: "ECB",
+        name: "European Central Bank",
+        base_currency: "EUR",
+      },
+      # Future sources (require feed implementation):
+      # { code: "BOC", name: "Bank of Canada", base_currency: "CAD" },
+    ]
+
+    sources_data.each do |data|
+      Source.dataset.insert_conflict(target: :code, update: data).insert(data)
+    end
+
+    count = Source.count
+    puts "Seeded #{count} source#{'s' unless count == 1}"
+  end
+end

--- a/lib/versions/v2.rb
+++ b/lib/versions/v2.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "digest"
+require "oj"
+require "roda"
+
+require "currency_names"
+require "query"
+require "quote"
+require "source"
+
+module Versions
+  class V2 < Roda
+    plugin :json,
+      content_type: "application/json; charset=utf-8",
+      serializer: ->(o) { Oj.dump(o, mode: :compat) }
+
+    plugin :caching
+    plugin :indifferent_params
+    plugin :params_capturing
+    plugin :halt
+
+    route do |r|
+      response.cache_control(public: true, max_age: 900)
+
+      # GET /v2/latest
+      r.is(/latest|current/) do
+        r.params["date"] = Date.today.to_s
+        quote = quote_end_of_day(r)
+        r.etag(quote.cache_key)
+
+        quote.formatted
+      end
+
+      # GET /v2/YYYY-MM-DD
+      r.is(/(\d{4}-\d{2}-\d{2})/) do
+        r.params["date"] = r.params["captures"].first
+        quote = quote_end_of_day(r)
+        r.etag(quote.cache_key)
+
+        quote.formatted
+      end
+
+      # GET /v2/YYYY-MM-DD..YYYY-MM-DD
+      r.is(/(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})?/) do
+        r.params["start_date"] = r.params["captures"].first
+        r.params["end_date"] = r.params["captures"][1] || Date.today.to_s
+        quote = quote_interval(r)
+        r.etag(quote.cache_key)
+
+        quote.formatted
+      end
+
+      # GET /v2/sources
+      r.is("sources") do
+        sources = Source.all.map do |s|
+          {
+            code: s.code,
+            name: s.name,
+            base_currency: s.base_currency,
+          }
+        end
+
+        cache_key = Digest::MD5.hexdigest(sources.to_s)
+        r.etag(cache_key)
+
+        { sources: sources }
+      end
+
+      # GET /v2/currencies
+      r.is("currencies") do
+        currency_names = CurrencyNames.new
+        r.etag(currency_names.cache_key)
+
+        currency_names.formatted
+      end
+    end
+
+    private
+
+    def quote_end_of_day(request)
+      # V2 always includes source key to enable strict source resolution
+      params_with_source = request.params.merge(source: request.params[:source])
+      query = Query.build(params_with_source)
+      quote = Quote::EndOfDay.new(**query)
+      quote.perform
+      request.halt(404, { message: "not found" }) if quote.not_found?
+
+      quote
+    rescue ArgumentError => e
+      request.halt(400, { error: e.message })
+    end
+
+    def quote_interval(request)
+      # V2 always includes source key to enable strict source resolution
+      params_with_source = request.params.merge(source: request.params[:source])
+      query = Query.build(params_with_source)
+      quote = Quote::Interval.new(**query)
+      quote.perform
+      request.halt(404, { message: "not found" }) if quote.not_found?
+
+      quote
+    rescue ArgumentError => e
+      request.halt(400, { error: e.message })
+    end
+  end
+end

--- a/spec/versions/v1_spec.rb
+++ b/spec/versions/v1_spec.rb
@@ -106,4 +106,10 @@ describe Versions::V1 do
 
     _(last_response.headers["content-type"]).must_be(:end_with?, "charset=utf-8")
   end
+
+  it "filters by source parameter" do
+    get "/latest?source=ECB"
+
+    _(last_response).must_be(:ok?)
+  end
 end

--- a/spec/versions/v2_spec.rb
+++ b/spec/versions/v2_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "rack/test"
+require "versions/v2"
+
+describe Versions::V2 do
+  include Rack::Test::Methods
+
+  let(:app) { Versions::V2.freeze }
+  let(:json) { Oj.load(last_response.body) }
+  let(:headers) { last_response.headers }
+
+  describe "GET /latest" do
+    it "returns latest quotes with source field" do
+      get "/latest?from=EUR&to=USD"
+
+      _(last_response).must_be(:ok?)
+      _(json["source"]).must_equal("ECB")
+      _(json["base"]).must_equal("EUR")
+      _(json["rates"]).must_include("USD")
+    end
+
+    it "returns rates with default base when from parameter omitted" do
+      get "/latest"
+
+      _(last_response).must_be(:ok?)
+      _(json["base"]).must_equal("EUR")
+    end
+
+    it "filters target currencies with to parameter" do
+      get "/latest?from=EUR&to=USD,GBP"
+
+      _(json["rates"].keys.sort).must_equal(["GBP", "USD"])
+    end
+
+    it "converts amounts" do
+      get "/latest?from=EUR&to=USD&amount=100"
+
+      _(json["amount"]).must_equal(100)
+      _(json["rates"]["USD"]).must_be(:>, 100)
+    end
+
+    it "returns error when from currency has no native source" do
+      get "/latest?from=USD&to=EUR"
+
+      _(last_response.status).must_equal(400)
+      _(json["error"]).must_match(/No source found|No data available/)
+    end
+
+    it "allows cross-source conversion with explicit source parameter" do
+      get "/latest?from=USD&to=EUR&source=ECB"
+
+      _(last_response).must_be(:ok?)
+      _(json["source"]).must_equal("ECB")
+      _(json["base"]).must_equal("USD")
+    end
+
+    it "returns error for invalid source" do
+      get "/latest?from=EUR&to=USD&source=INVALID"
+
+      _(last_response.status).must_equal(400)
+      _(json["error"]).must_match(/Source.*not found/)
+    end
+
+    it "returns ETag header" do
+      get "/latest?from=EUR"
+
+      _(headers["ETag"]).wont_be_nil
+    end
+
+    it "returns Cache-Control header" do
+      get "/latest?from=EUR"
+
+      _(headers["Cache-Control"]).must_include("public")
+      _(headers["Cache-Control"]).must_include("max-age")
+    end
+
+    it "sets charset to utf-8" do
+      get "/latest?from=EUR"
+
+      _(last_response.headers["content-type"]).must_be(:end_with?, "charset=utf-8")
+    end
+  end
+
+  describe "GET /:date" do
+    it "returns historical quotes for specific date" do
+      get "/2012-11-20?from=EUR&to=USD"
+
+      _(last_response).must_be(:ok?)
+      _(json["date"]).must_equal("2012-11-20")
+      _(json["source"]).must_equal("ECB")
+      _(json["rates"]).must_include("USD")
+    end
+
+    it "works around weekends and holidays" do
+      get "/2010-01-01?from=EUR"
+
+      _(last_response).must_be(:ok?)
+      _(json["rates"]).wont_be(:empty?)
+    end
+
+    it "returns latest quotes when querying future date" do
+      tomorrow = (Date.today + 1).to_s
+      get "/#{tomorrow}?from=EUR"
+
+      _(last_response).must_be(:ok?)
+    end
+
+    it "allows explicit source for historical data" do
+      get "/2012-11-20?from=USD&to=EUR&source=ECB"
+
+      _(last_response).must_be(:ok?)
+      _(json["source"]).must_equal("ECB")
+      _(json["base"]).must_equal("USD")
+    end
+
+    it "converts amounts for historical dates" do
+      get "/2012-11-20?from=EUR&to=USD&amount=50"
+
+      _(json["amount"]).must_equal(50)
+      _(json["rates"]["USD"]).must_be(:>, 50)
+    end
+
+    it "returns error when from currency has no native source" do
+      get "/2012-11-20?from=USD"
+
+      _(last_response.status).must_equal(400)
+    end
+  end
+
+  describe "GET /:start_date..:end_date" do
+    it "returns rates for date range" do
+      get "/2010-01-01..2010-01-31?from=EUR&to=USD"
+
+      _(last_response).must_be(:ok?)
+      _(json["start_date"]).wont_be_nil
+      _(json["end_date"]).wont_be_nil
+      _(json["source"]).must_equal("ECB")
+      _(json["rates"]).wont_be(:empty?)
+    end
+
+    it "returns rates when end date is omitted" do
+      get "/2010-01-01..?from=EUR"
+
+      _(last_response).must_be(:ok?)
+      _(json["start_date"]).wont_be(:empty?)
+      _(json["end_date"]).wont_be(:empty?)
+    end
+
+    it "allows explicit source for date ranges" do
+      get "/2010-01-01..2010-01-31?from=USD&to=EUR&source=ECB"
+
+      _(last_response).must_be(:ok?)
+      _(json["source"]).must_equal("ECB")
+    end
+
+    it "converts amounts for date ranges" do
+      get "/2010-01-01..2010-01-31?from=EUR&to=USD&amount=100"
+
+      _(json["amount"]).must_equal(100)
+    end
+  end
+
+  describe "GET /sources" do
+    it "returns list of available sources" do
+      get "/sources"
+
+      _(last_response).must_be(:ok?)
+      _(json["sources"]).must_be_instance_of(Array)
+      _(json["sources"]).wont_be(:empty?)
+    end
+
+    it "includes source details" do
+      get "/sources"
+
+      source = json["sources"].first
+      _(source).must_include("code")
+      _(source).must_include("name")
+      _(source).must_include("base_currency")
+    end
+
+    it "includes ECB as a source" do
+      get "/sources"
+
+      ecb = json["sources"].find { |s| s["code"] == "ECB" }
+      _(ecb).wont_be_nil
+      _(ecb["name"]).must_equal("European Central Bank")
+      _(ecb["base_currency"]).must_equal("EUR")
+    end
+  end
+end


### PR DESCRIPTION
defaults to strict source mode (native source required for each currency), with cross-source rebasing available via explicit
  `&source` parameter.