### PR TITLE
feat: Modularize exchange-rate providers and add UAH, AMD, BYN, and BWP support

### DIFF
--- a/lib/bank.rb
+++ b/lib/bank.rb
@@ -1,41 +1,42 @@
 # frozen_string_literal: true
 
-require "bank/feed"
+require "bank/importer"
 require "currency"
 
 module Bank
   class << self
     def fetch_all!
-      data = normalize_data(Feed.historical.to_a)
+      data = normalize_data(importer.historical)
       Currency.dataset.insert_conflict.multi_insert(data)
     end
 
     def fetch_ninety_days!
-      data = normalize_data(Feed.ninety_days.to_a)
+      data = normalize_data(importer.ninety_days)
       Currency.dataset.insert_conflict.multi_insert(data)
     end
 
     def fetch_current!
-      data = normalize_data(Feed.current.to_a)
-      # Use multi_insert only if we have multiple records
-      if data.is_a?(Array)
-        Currency.dataset.insert_conflict.multi_insert(data)
-      end
+      data = normalize_data(importer.current)
+      Currency.dataset.insert_conflict.multi_insert(data) if data.any?
     end
 
     def replace_all!
-      data = normalize_data(Feed.historical.to_a)
+      data = normalize_data(importer.historical)
       Currency.dataset.delete
       Currency.multi_insert(data)
     end
 
     def seed_with_saved_data!
-      data = normalize_data(Feed.saved_data.to_a)
+      data = normalize_data(importer.saved_data)
       Currency.dataset.delete
       Currency.multi_insert(data)
     end
 
     private
+
+    def importer
+      @importer ||= Importer.new
+    end
 
     def normalize_data(days)
       days.flat_map do |day|

--- a/lib/bank/feed.rb
+++ b/lib/bank/feed.rb
@@ -1,50 +1,30 @@
 # frozen_string_literal: true
 
-require "net/http"
-require "ox"
+require "bank/providers/ecb"
 
 module Bank
   class Feed
-    include Enumerable
-
     class << self
       def current
-        url = URI("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml")
-        xml = Net::HTTP.get(url)
-
-        new(xml)
+        provider.current
       end
 
       def ninety_days
-        url = URI("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml")
-        xml = Net::HTTP.get(url)
-
-        new(xml)
+        provider.ninety_days
       end
 
       def historical
-        url = URI("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml")
-        xml = Net::HTTP.get(url)
-
-        new(xml)
+        provider.historical
       end
 
       def saved_data
-        xml = File.read(File.join(__dir__, "eurofxref-hist.xml"))
-        new(xml)
+        provider.saved_data
       end
-    end
 
-    def initialize(xml)
-      @document = Ox.load(xml)
-    end
+      private
 
-    def each
-      @document.locate("gesmes:Envelope/Cube/Cube").each do |day|
-        yield(date: Date.parse(day["time"]),
-              rates: day.nodes.each_with_object({}) do |currency, rates|
-                rates[currency[:currency]] = Float(currency[:rate])
-              end)
+      def provider
+        @provider ||= Bank::Providers::ECB.new
       end
     end
   end

--- a/lib/bank/importer.rb
+++ b/lib/bank/importer.rb
@@ -2,6 +2,7 @@
 
 require "bank/provider"
 require "bank/providers/ecb"
+require "bank/providers/nbu"
 
 module Bank
   class Importer
@@ -9,7 +10,7 @@ module Bank
       attr_writer :providers
 
       def providers
-        @providers ||= [Bank::Providers::ECB.new].freeze
+        @providers ||= [Bank::Providers::ECB.new, Bank::Providers::NBU.new].freeze
       end
     end
 

--- a/lib/bank/importer.rb
+++ b/lib/bank/importer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "bank/provider"
+require "bank/providers/ecb"
+
+module Bank
+  class Importer
+    class << self
+      attr_writer :providers
+
+      def providers
+        @providers ||= [Bank::Providers::ECB.new].freeze
+      end
+    end
+
+    def initialize(providers: self.class.providers)
+      @providers = providers
+    end
+
+    def current
+      import(:current)
+    end
+
+    def ninety_days
+      import(:ninety_days)
+    end
+
+    def historical
+      import(:historical)
+    end
+
+    def saved_data
+      import(:saved_data)
+    end
+
+    private
+
+    attr_reader :providers
+
+    def import(dataset)
+      providers.each_with_object({}) do |provider, result|
+        provider.public_send(dataset).each do |day|
+          result[day[:date]] ||= {}
+          day[:rates].each do |iso_code, rate|
+            result[day[:date]][iso_code] ||= rate
+          end
+        end
+      end.sort.map do |date, rates|
+        { date: date, rates: rates }
+      end
+    end
+  end
+end

--- a/lib/bank/importer.rb
+++ b/lib/bank/importer.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "bank/provider"
+require "bank/providers/bob"
+require "bank/providers/cba"
 require "bank/providers/ecb"
 require "bank/providers/nbu"
+require "bank/providers/nbrb"
 
 module Bank
   class Importer
@@ -10,7 +13,13 @@ module Bank
       attr_writer :providers
 
       def providers
-        @providers ||= [Bank::Providers::ECB.new, Bank::Providers::NBU.new].freeze
+        @providers ||= [
+          Bank::Providers::ECB.new,
+          Bank::Providers::NBU.new,
+          Bank::Providers::CBA.new,
+          Bank::Providers::NBRB.new,
+          Bank::Providers::BOB.new,
+        ].freeze
       end
     end
 

--- a/lib/bank/provider.rb
+++ b/lib/bank/provider.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Bank
+  class Provider
+    def current
+      raise NotImplementedError
+    end
+
+    def ninety_days
+      raise NotImplementedError
+    end
+
+    def historical
+      raise NotImplementedError
+    end
+
+    def saved_data
+      raise NotImplementedError
+    end
+
+    def supported_currencies
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/bank/providers/bob.rb
+++ b/lib/bank/providers/bob.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "date"
+require "net/http"
+
+require "bank/provider"
+
+module Bank
+  module Providers
+    class BOB < Provider
+      CSV_URL = URI("https://www.bankofbotswana.bw/export/exchange-rates.csv?page&_format=csv")
+
+      def current
+        historical.last(1)
+      end
+
+      def ninety_days
+        cutoff = Date.today - 120
+        historical.select { |day| day[:date] >= cutoff }
+      end
+
+      def historical
+        parse(Net::HTTP.get(CSV_URL))
+      end
+
+      def saved_data
+        []
+      end
+
+      def supported_currencies
+        ["BWP"]
+      end
+
+      private
+
+      def parse(csv)
+        rows = csv.delete_prefix("\uFEFF").lines(chomp: true)
+        headers = rows.shift&.split(",")
+        eur_index = headers&.index("EUR")
+        date_index = headers&.index("Date")
+        return [] unless eur_index && date_index
+
+        rows.filter_map do |line|
+          values = line.delete('"').split(",")
+          eur = values[eur_index]
+          next if eur.nil? || eur.empty?
+
+          rate = Float(eur)
+          next if rate.zero?
+
+          {
+            date: Date.strptime(values[date_index], "%d %b %Y"),
+            rates: { "BWP" => 1 / rate },
+          }
+        end.reverse
+      end
+    end
+  end
+end

--- a/lib/bank/providers/cba.rb
+++ b/lib/bank/providers/cba.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "date"
+require "net/http"
+require "ox"
+
+require "bank/provider"
+
+module Bank
+  module Providers
+    class CBA < Provider
+      EARLIEST_DATE = Date.new(1999, 1, 4)
+      CHUNK_SIZE = 365
+      URL = URI("https://api.cba.am/exchangerates.asmx")
+
+      def current
+        result = latest_quote
+        return [] unless result
+
+        [result]
+      end
+
+      def ninety_days
+        range(Date.today - 120, Date.today)
+      end
+
+      def historical
+        chunked_range(EARLIEST_DATE, Date.today)
+      end
+
+      def saved_data
+        []
+      end
+
+      def supported_currencies
+        ["AMD"]
+      end
+
+      private
+
+      def latest_quote
+        response = request("ExchangeRatesLatest", <<~XML)
+          <ExchangeRatesLatest xmlns="http://www.cba.am/" />
+        XML
+
+        result = response.locate("soap:Envelope/soap:Body/ExchangeRatesLatestResponse/ExchangeRatesLatestResult").first
+        return unless result
+
+        current_date = result.locate("CurrentDate").first
+        eur = result.locate("Rates/ExchangeRate").find { |node| node.locate("ISO").first&.text == "EUR" }
+        return unless current_date && eur
+
+        {
+          date: Date.parse(current_date.text),
+          rates: { "AMD" => extract_rate(eur) },
+        }
+      end
+
+      def chunked_range(start_date, end_date)
+        days = []
+        chunk_start = start_date
+
+        while chunk_start <= end_date
+          chunk_end = [chunk_start + CHUNK_SIZE - 1, end_date].min
+          days.concat(range(chunk_start, chunk_end))
+          chunk_start = chunk_end + 1
+        end
+
+        days
+      end
+
+      def range(start_date, end_date)
+        response = request("ExchangeRatesByDateRangeByISO", <<~XML)
+          <ExchangeRatesByDateRangeByISO xmlns="http://www.cba.am/">
+            <ISOCodes>EUR</ISOCodes>
+            <DateFrom>#{start_date}</DateFrom>
+            <DateTo>#{end_date}</DateTo>
+          </ExchangeRatesByDateRangeByISO>
+        XML
+
+        response
+          .locate("soap:Envelope/soap:Body/ExchangeRatesByDateRangeByISOResponse/ExchangeRatesByDateRangeByISOResult/diffgr:diffgram/DocumentElement/ExchangeRatesByRange")
+          .map do |row|
+            {
+              date: Date.parse(row.locate("RateDate").first.text),
+              rates: { "AMD" => extract_rate(row) },
+            }
+          end
+      end
+
+      def request(action, payload)
+        xml = <<~XML
+          <?xml version="1.0" encoding="utf-8"?>
+          <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                         xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+            <soap:Body>
+              #{payload.strip}
+            </soap:Body>
+          </soap:Envelope>
+        XML
+
+        Ox.load(
+          Net::HTTP.post(
+            URL,
+            xml,
+            {
+              "Content-Type" => "text/xml; charset=utf-8",
+              "SOAPAction" => "\"http://www.cba.am/#{action}\"",
+            },
+          ).body,
+        )
+      end
+
+      def extract_rate(node)
+        amount = Integer(node.locate("Amount").first.text)
+        rate = Float(node.locate("Rate").first.text)
+        rate / amount
+      end
+    end
+  end
+end

--- a/lib/bank/providers/ecb.rb
+++ b/lib/bank/providers/ecb.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "date"
+require "net/http"
+require "ox"
+
+require "bank/provider"
+
+module Bank
+  module Providers
+    class ECB < Provider
+      CURRENT_URL = URI("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml")
+      NINETY_DAYS_URL = URI("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist-90d.xml")
+      HISTORICAL_URL = URI("https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml")
+
+      SUPPORTED_CURRENCIES = %w[
+        AUD BGN BRL CAD CHF CNY CZK DKK GBP HKD HUF IDR ILS INR ISK JPY KRW MXN
+        MYR NOK NZD PHP PLN RON SEK SGD THB TRY USD ZAR
+      ].freeze
+
+      def current
+        parse(Net::HTTP.get(CURRENT_URL))
+      end
+
+      def ninety_days
+        parse(Net::HTTP.get(NINETY_DAYS_URL))
+      end
+
+      def historical
+        parse(Net::HTTP.get(HISTORICAL_URL))
+      end
+
+      def saved_data
+        parse(File.read(File.join(__dir__, "..", "eurofxref-hist.xml")))
+      end
+
+      def supported_currencies
+        SUPPORTED_CURRENCIES
+      end
+
+      private
+
+      def parse(xml)
+        Feed.new(xml)
+      end
+
+      class Feed
+        include Enumerable
+
+        def initialize(xml)
+          @document = Ox.load(xml)
+        end
+
+        def each
+          @document.locate("gesmes:Envelope/Cube/Cube").each do |day|
+            yield({
+              date: Date.parse(day["time"]),
+              rates: day.nodes.each_with_object({}) do |currency, rates|
+                rates[currency[:currency]] = Float(currency[:rate])
+              end,
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bank/providers/nbrb.rb
+++ b/lib/bank/providers/nbrb.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "date"
+require "net/http"
+require "oj"
+
+require "bank/provider"
+
+module Bank
+  module Providers
+    class NBRB < Provider
+      EARLIEST_DATE = Date.new(1999, 1, 4)
+      CURRENT_URL = "https://api.nbrb.by/exrates/rates/EUR?parammode=2"
+      DYNAMICS_URL = "https://api.nbrb.by/exrates/rates/dynamics"
+
+      def current
+        row = Oj.load(Net::HTTP.get(URI(CURRENT_URL)))
+
+        [
+          {
+            date: Date.parse(row.fetch("Date")),
+            rates: { "BYN" => extract_rate(row) },
+          },
+        ]
+      end
+
+      def ninety_days
+        range(Date.today - 120, Date.today)
+      end
+
+      def historical
+        range(EARLIEST_DATE, Date.today)
+      end
+
+      def saved_data
+        []
+      end
+
+      def supported_currencies
+        ["BYN"]
+      end
+
+      private
+
+      def range(start_date, end_date)
+        url = URI("#{DYNAMICS_URL}/#{currency_id}")
+        url.query = URI.encode_www_form(
+          startDate: start_date.to_s,
+          endDate: end_date.to_s,
+        )
+
+        Oj.load(Net::HTTP.get(url)).filter_map do |row|
+          date = Date.parse(row.fetch("Date"))
+          next if date.saturday? || date.sunday?
+
+          {
+            date: date,
+            rates: { "BYN" => Float(row.fetch("Cur_OfficialRate")) },
+          }
+        end
+      end
+
+      def currency_id
+        @currency_id ||= Oj.load(Net::HTTP.get(URI(CURRENT_URL))).fetch("Cur_ID")
+      end
+
+      def extract_rate(row)
+        Float(row.fetch("Cur_OfficialRate")) / Integer(row.fetch("Cur_Scale"))
+      end
+    end
+  end
+end

--- a/lib/bank/providers/nbu.rb
+++ b/lib/bank/providers/nbu.rb
@@ -42,6 +42,7 @@ module Bank
 
           date = Date.strptime(row.fetch("exchangedate"), "%d.%m.%Y")
           next if date > end_date
+          next if date.saturday? || date.sunday?
 
           {
             date: date,
@@ -65,11 +66,15 @@ module Bank
       end
 
       def extract_rate(row)
+        units = row.fetch("units", 1).to_f
+        rate_per_unit = row["rate_per_unit"]
         rate = row["rate"]
-        rate_per_unit = row.fetch("rate_per_unit", 1).to_f
-        return if rate.nil? || rate_per_unit.zero?
+        return if units.zero?
 
-        rate.to_f / rate_per_unit
+        return rate_per_unit.to_f if rate_per_unit
+        return if rate.nil?
+
+        rate.to_f / units
       end
     end
   end

--- a/lib/bank/providers/nbu.rb
+++ b/lib/bank/providers/nbu.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "date"
+require "net/http"
+require "oj"
+
+require "bank/provider"
+
+module Bank
+  module Providers
+    class NBU < Provider
+      EARLIEST_DATE = Date.new(1999, 1, 4)
+      RANGE_URL = URI("https://bank.gov.ua/NBU_Exchange/exchange_site")
+
+      def current
+        range(Date.today - 7, Date.today).last(1)
+      end
+
+      def ninety_days
+        range(Date.today - 120, Date.today)
+      end
+
+      def historical
+        range(EARLIEST_DATE, Date.today)
+      end
+
+      def saved_data
+        []
+      end
+
+      def supported_currencies
+        ["UAH"]
+      end
+
+      private
+
+      def range(start_date, end_date)
+        rows = fetch_rows(start_date, end_date)
+        rows.filter_map do |row|
+          rate = extract_rate(row)
+          next unless rate
+
+          date = Date.strptime(row.fetch("exchangedate"), "%d.%m.%Y")
+          next if date > end_date
+
+          {
+            date: date,
+            rates: { "UAH" => rate },
+          }
+        end.sort_by { |day| day[:date] }
+      end
+
+      def fetch_rows(start_date, end_date)
+        url = RANGE_URL.dup
+        url.query = URI.encode_www_form(
+          start: start_date.strftime("%Y%m%d"),
+          end: end_date.strftime("%Y%m%d"),
+          valcode: "EUR",
+          sort: "exchangedate",
+          order: "asc",
+          json: "",
+        )
+
+        Oj.load(Net::HTTP.get(url))
+      end
+
+      def extract_rate(row)
+        rate = row["rate"]
+        rate_per_unit = row.fetch("rate_per_unit", 1).to_f
+        return if rate.nil? || rate_per_unit.zero?
+
+        rate.to_f / rate_per_unit
+      end
+    end
+  end
+end

--- a/spec/bank/importer_spec.rb
+++ b/spec/bank/importer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "bank/importer"
+
+describe Bank::Importer do
+  class StubProvider < Bank::Provider
+    def initialize(datasets)
+      @datasets = datasets
+    end
+
+    def current
+      @datasets.fetch(:current)
+    end
+
+    def ninety_days
+      @datasets.fetch(:ninety_days, [])
+    end
+
+    def historical
+      @datasets.fetch(:historical, [])
+    end
+
+    def saved_data
+      @datasets.fetch(:saved_data, [])
+    end
+
+    def supported_currencies
+      []
+    end
+  end
+
+  it "keeps the first provider as authoritative for overlapping currencies" do
+    primary = StubProvider.new(
+      current: [
+        { date: Date.new(2025, 1, 1), rates: { "USD" => 1.03, "GBP" => 0.83 } },
+      ],
+    )
+    fallback = StubProvider.new(
+      current: [
+        { date: Date.new(2025, 1, 1), rates: { "USD" => 9.99, "AED" => 3.78 } },
+      ],
+    )
+
+    result = described_class.new(providers: [primary, fallback]).current
+
+    _(result).must_equal(
+      [
+        {
+          date: Date.new(2025, 1, 1),
+          rates: { "USD" => 1.03, "GBP" => 0.83, "AED" => 3.78 },
+        },
+      ],
+    )
+  end
+
+  it "merges dates across providers" do
+    provider_one = StubProvider.new(
+      historical: [
+        { date: Date.new(2025, 1, 1), rates: { "USD" => 1.03 } },
+      ],
+    )
+    provider_two = StubProvider.new(
+      historical: [
+        { date: Date.new(2025, 1, 2), rates: { "AED" => 3.78 } },
+      ],
+    )
+
+    result = described_class.new(providers: [provider_one, provider_two]).historical
+
+    _(result).must_equal(
+      [
+        { date: Date.new(2025, 1, 1), rates: { "USD" => 1.03 } },
+        { date: Date.new(2025, 1, 2), rates: { "AED" => 3.78 } },
+      ],
+    )
+  end
+end

--- a/spec/bank/importer_spec.rb
+++ b/spec/bank/importer_spec.rb
@@ -42,7 +42,7 @@ describe Bank::Importer do
       ],
     )
 
-    result = described_class.new(providers: [primary, fallback]).current
+    result = Bank::Importer.new(providers: [primary, fallback]).current
 
     _(result).must_equal(
       [
@@ -66,7 +66,7 @@ describe Bank::Importer do
       ],
     )
 
-    result = described_class.new(providers: [provider_one, provider_two]).historical
+    result = Bank::Importer.new(providers: [provider_one, provider_two]).historical
 
     _(result).must_equal(
       [

--- a/spec/bank/providers/bob_spec.rb
+++ b/spec/bank/providers/bob_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "../../helper"
+require "bank/providers/bob"
+
+describe Bank::Providers::BOB do
+  before do
+    stub_request(:get, "https://www.bankofbotswana.bw/export/exchange-rates.csv?page&_format=csv")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "text/csv" },
+        body: <<~CSV,
+          Date,CHN,EUR,GBP,USD,SDR,YEN,ZAR
+          "13 Mar 2026",0.5188,0.0655,0.0565,0.0753,0.0554,12.0000,1.2666
+          "12 Mar 2026",0.5228,0.0658,0.0568,0.0760,0.0558,12.0800,1.2581
+        CSV
+      )
+  end
+
+  it "reports BWP as the supported currency" do
+    provider = Bank::Providers::BOB.new
+
+    _(provider.supported_currencies).must_equal(["BWP"])
+  end
+
+  it "parses EUR quotes into BWP rates" do
+    provider = Bank::Providers::BOB.new
+
+    _(provider.historical).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 12),
+          rates: { "BWP" => 1 / 0.0658 },
+        },
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "BWP" => 1 / 0.0655 },
+        },
+      ],
+    )
+  end
+
+  it "returns the latest available row for current rates" do
+    provider = Bank::Providers::BOB.new
+
+    _(provider.current).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "BWP" => 1 / 0.0655 },
+        },
+      ],
+    )
+  end
+end

--- a/spec/bank/providers/cba_spec.rb
+++ b/spec/bank/providers/cba_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "../../helper"
+require "bank/providers/cba"
+
+describe Bank::Providers::CBA do
+  before do
+    stub_request(:post, "https://api.cba.am/exchangerates.asmx")
+      .with(headers: { "SOAPAction" => "\"http://www.cba.am/ExchangeRatesLatest\"" })
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "text/xml" },
+        body: <<~XML,
+          <?xml version="1.0" encoding="utf-8"?>
+          <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+            <soap:Body>
+              <ExchangeRatesLatestResponse xmlns="http://www.cba.am/">
+                <ExchangeRatesLatestResult>
+                  <CurrentDate>2026-03-13T00:00:00</CurrentDate>
+                  <Rates>
+                    <ExchangeRate>
+                      <ISO>USD</ISO>
+                      <Amount>1</Amount>
+                      <Rate>377.54</Rate>
+                    </ExchangeRate>
+                    <ExchangeRate>
+                      <ISO>EUR</ISO>
+                      <Amount>1</Amount>
+                      <Rate>432.7</Rate>
+                    </ExchangeRate>
+                  </Rates>
+                </ExchangeRatesLatestResult>
+              </ExchangeRatesLatestResponse>
+            </soap:Body>
+          </soap:Envelope>
+        XML
+      )
+
+    stub_request(:post, "https://api.cba.am/exchangerates.asmx")
+      .with(headers: { "SOAPAction" => "\"http://www.cba.am/ExchangeRatesByDateRangeByISO\"" })
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "text/xml" },
+        body: <<~XML,
+          <?xml version="1.0" encoding="utf-8"?>
+          <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+            <soap:Body>
+              <ExchangeRatesByDateRangeByISOResponse xmlns="http://www.cba.am/">
+                <ExchangeRatesByDateRangeByISOResult>
+                  <diffgr:diffgram xmlns:diffgr="urn:schemas-microsoft-com:xml-diffgram-v1">
+                    <DocumentElement xmlns="">
+                      <ExchangeRatesByRange>
+                        <Rate>436.25</Rate>
+                        <Amount>1</Amount>
+                        <ISO>EUR</ISO>
+                        <RateDate>2026-03-12T00:00:00+04:00</RateDate>
+                      </ExchangeRatesByRange>
+                      <ExchangeRatesByRange>
+                        <Rate>432.7</Rate>
+                        <Amount>1</Amount>
+                        <ISO>EUR</ISO>
+                        <RateDate>2026-03-13T00:00:00+04:00</RateDate>
+                      </ExchangeRatesByRange>
+                    </DocumentElement>
+                  </diffgr:diffgram>
+                </ExchangeRatesByDateRangeByISOResult>
+              </ExchangeRatesByDateRangeByISOResponse>
+            </soap:Body>
+          </soap:Envelope>
+        XML
+      )
+  end
+
+  it "reports AMD as the supported currency" do
+    provider = Bank::Providers::CBA.new
+
+    _(provider.supported_currencies).must_equal(["AMD"])
+  end
+
+  it "parses the latest EUR quote into AMD rates" do
+    provider = Bank::Providers::CBA.new
+
+    _(provider.current).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "AMD" => 432.7 },
+        },
+      ],
+    )
+  end
+
+  it "parses historical EUR quotes into AMD rates" do
+    provider = Bank::Providers::CBA.new
+
+    _(provider.historical.first(2)).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 12),
+          rates: { "AMD" => 436.25 },
+        },
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "AMD" => 432.7 },
+        },
+      ],
+    )
+  end
+end

--- a/spec/bank/providers/nbrb_spec.rb
+++ b/spec/bank/providers/nbrb_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative "../../helper"
+require "oj"
+require "bank/providers/nbrb"
+
+describe Bank::Providers::NBRB do
+  before do
+    stub_request(:get, "https://api.nbrb.by/exrates/rates/EUR?parammode=2")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: Oj.dump(
+          {
+            "Cur_ID" => 451,
+            "Date" => "2026-03-13T00:00:00",
+            "Cur_Abbreviation" => "EUR",
+            "Cur_Scale" => 1,
+            "Cur_OfficialRate" => 3.3824,
+          },
+        ),
+      )
+
+    stub_request(:get, "https://api.nbrb.by/exrates/rates/dynamics/451")
+      .with(query: hash_including("startDate" => "1999-01-04"))
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: Oj.dump(
+          [
+            {
+              "Date" => "2026-03-12T00:00:00",
+              "Cur_OfficialRate" => 3.3920,
+            },
+            {
+              "Date" => "2026-03-13T00:00:00",
+              "Cur_OfficialRate" => 3.3824,
+            },
+            {
+              "Date" => "2026-03-14T00:00:00",
+              "Cur_OfficialRate" => 3.3824,
+            },
+          ],
+        ),
+      )
+  end
+
+  it "reports BYN as the supported currency" do
+    provider = Bank::Providers::NBRB.new
+
+    _(provider.supported_currencies).must_equal(["BYN"])
+  end
+
+  it "parses the latest EUR quote into BYN rates" do
+    provider = Bank::Providers::NBRB.new
+
+    _(provider.current).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "BYN" => 3.3824 },
+        },
+      ],
+    )
+  end
+
+  it "parses historical EUR quotes into BYN rates and skips weekends" do
+    provider = Bank::Providers::NBRB.new
+
+    _(provider.historical.last(2)).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 12),
+          rates: { "BYN" => 3.3920 },
+        },
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "BYN" => 3.3824 },
+        },
+      ],
+    )
+  end
+end

--- a/spec/bank/providers/nbu_spec.rb
+++ b/spec/bank/providers/nbu_spec.rb
@@ -47,13 +47,13 @@ describe Bank::Providers::NBU do
   end
 
   it "reports UAH as the supported currency" do
-    provider = described_class.new
+    provider = Bank::Providers::NBU.new
 
     _(provider.supported_currencies).must_equal(["UAH"])
   end
 
   it "parses historical EUR quotes into UAH rates" do
-    provider = described_class.new
+    provider = Bank::Providers::NBU.new
     result = provider.historical
 
     _(result).must_equal(
@@ -71,14 +71,14 @@ describe Bank::Providers::NBU do
   end
 
   it "skips weekend effective dates" do
-    provider = described_class.new
+    provider = Bank::Providers::NBU.new
     result = provider.historical
 
     _(result.map { |day| day[:date] }).wont_include(Date.new(2026, 3, 14))
   end
 
   it "returns the last available row for current rates" do
-    provider = described_class.new
+    provider = Bank::Providers::NBU.new
     days = [
       {
         date: Date.new(2026, 3, 13),

--- a/spec/bank/providers/nbu_spec.rb
+++ b/spec/bank/providers/nbu_spec.rb
@@ -24,13 +24,22 @@ describe Bank::Providers::NBU do
               "exchangedate" => "13.03.2026",
               "cc" => "EUR",
               "rate" => 45.0912,
-              "rate_per_unit" => 1,
+              "rate_per_unit" => 45.0912,
+              "units" => 1,
             },
             {
               "exchangedate" => "16.03.2026",
               "cc" => "EUR",
               "rate" => 45.3201,
-              "rate_per_unit" => 1,
+              "rate_per_unit" => 45.3201,
+              "units" => 1,
+            },
+            {
+              "exchangedate" => "14.03.2026",
+              "cc" => "EUR",
+              "rate" => 45.5000,
+              "rate_per_unit" => 45.5000,
+              "units" => 1,
             },
           ],
         ),
@@ -59,6 +68,13 @@ describe Bank::Providers::NBU do
         },
       ],
     )
+  end
+
+  it "skips weekend effective dates" do
+    provider = described_class.new
+    result = provider.historical
+
+    _(result.map { |day| day[:date] }).wont_include(Date.new(2026, 3, 14))
   end
 
   it "returns the last available row for current rates" do

--- a/spec/bank/providers/nbu_spec.rb
+++ b/spec/bank/providers/nbu_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative "../../helper"
+require "oj"
+require "bank/providers/nbu"
+
+describe Bank::Providers::NBU do
+  before do
+    stub_request(:get, "https://bank.gov.ua/NBU_Exchange/exchange_site")
+      .with(
+        query: hash_including(
+          "valcode" => "EUR",
+          "sort" => "exchangedate",
+          "order" => "asc",
+          "json" => "",
+        ),
+      )
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: Oj.dump(
+          [
+            {
+              "exchangedate" => "13.03.2026",
+              "cc" => "EUR",
+              "rate" => 45.0912,
+              "rate_per_unit" => 1,
+            },
+            {
+              "exchangedate" => "16.03.2026",
+              "cc" => "EUR",
+              "rate" => 45.3201,
+              "rate_per_unit" => 1,
+            },
+          ],
+        ),
+      )
+  end
+
+  it "reports UAH as the supported currency" do
+    provider = described_class.new
+
+    _(provider.supported_currencies).must_equal(["UAH"])
+  end
+
+  it "parses historical EUR quotes into UAH rates" do
+    provider = described_class.new
+    result = provider.historical
+
+    _(result).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 13),
+          rates: { "UAH" => 45.0912 },
+        },
+        {
+          date: Date.new(2026, 3, 16),
+          rates: { "UAH" => 45.3201 },
+        },
+      ],
+    )
+  end
+
+  it "returns the last available row for current rates" do
+    provider = described_class.new
+    days = [
+      {
+        date: Date.new(2026, 3, 13),
+        rates: { "UAH" => 45.0912 },
+      },
+      {
+        date: Date.new(2026, 3, 16),
+        rates: { "UAH" => 45.3201 },
+      },
+    ]
+
+    result = provider.stub(:range, days) { provider.current }
+
+    _(result).must_equal(
+      [
+        {
+          date: Date.new(2026, 3, 16),
+          rates: { "UAH" => 45.3201 },
+        },
+      ],
+    )
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,7 +6,7 @@ require "minitest/autorun"
 require "minitest/around/spec"
 require "minitest/focus"
 require "vcr"
-require "webmock"
+require "webmock/minitest"
 
 VCR.configure do |c|
   c.cassette_library_dir = "spec/vcr_cassettes"


### PR DESCRIPTION
# Summary

1. extracts Frankfurter's exchange-rate ingestion into a modular provider/importer architecture
2. adds official central bank providers for currencies not covered by ECB

The branch now combines rates from multiple sources while keeping ECB authoritative for overlapping currencies. New official providers add support for:

- `UAH` via the National Bank of Ukraine (NBU)
- `AMD` via the Central Bank of Armenia (CBA)
- `BYN` via the National Bank of the Republic of Belarus (NBRB)
- `BWP` via the Bank of Botswana (BOB)

# What changed

- introduced `Bank::Provider` as the shared interface for rate providers
- extracted ECB logic into `Bank::Providers::ECB`
- added `Bank::Importer` to aggregate provider datasets for current, 90-day, historical, and saved-data imports
- updated `Bank` to import through `Bank::Importer` instead of relying on a single feed source
- kept first-provider precedence so ECB remains authoritative where currencies overlap
- added new providers for `UAH`, `AMD`, `BYN`, and `BWP`
- added importer coverage to verify cross-provider merging and overlap precedence
- added provider specs for parsing and current/historical import behavior
- fixed test setup by requiring `webmock/minitest`

# Provider details

- `NBU` fetches EUR to UAH data from the National Bank of Ukraine JSON API
- `CBA` uses the Central Bank of Armenia SOAP API and chunks historical requests
- `NBRB` imports EUR to BYN rates from the Belarus central bank JSON API
- `BOB` parses the Bank of Botswana CSV export and converts quoted EUR values into Frankfurter's EUR-base rate format

# Notes

- ECB remains the primary source for currencies it already covers
- additional providers only fill gaps, they do not overwrite ECB data
- the importer merges dates across providers and keeps the first rate seen for any overlapping currency on a given day
- provider modularity should make future currency additions much simpler

## Fixes

- Fixes #38
- Fixes #100
- Fixes #169
- Updates #144 

## Verification

```bash
mise exec ruby@3.4.8 -- bundle exec ruby -Ispec spec/bank/importer_spec.rb
mise exec ruby@3.4.8 -- bundle exec ruby -Ispec spec/bank/providers/cba_spec.rb
mise exec ruby@3.4.8 -- bundle exec ruby -Ispec spec/bank/providers/nbrb_spec.rb
mise exec ruby@3.4.8 -- bundle exec ruby -Ispec spec/bank/providers/bob_spec.rb
```
