### PR TITLE
Weight blended rates by recency

### DIFF
--- a/lib/blender.rb
+++ b/lib/blender.rb
@@ -38,7 +38,7 @@ class Blender
       weighted = group.map { |r| [r, recency_weight(reference_date - r[:date])] }
       total_weight = weighted.sum(&:last)
       rate = weighted.sum { |r, w| r[:rate] * w } / total_weight
-      weighted.max_by { |_, w| w }.first.merge(rate:)
+      group.max_by { |r| r[:date] }.merge(rate:)
     end
   end
 

--- a/lib/blender.rb
+++ b/lib/blender.rb
@@ -30,6 +30,8 @@ class Blender
     rebased = rates.group_by { |r| r[:provider] }.flat_map do |_, provider_rows|
       BaseConverter.new(provider_rows, base:).convert
     end
+    # Downsample queries return dates as strings (SQLite has no date type)
+    rebased.each { |r| r[:date] = Date.parse(r[:date]) unless r[:date].is_a?(Date) }
 
     reference_date = rebased.map { |r| r[:date] }.max
     rebased.group_by { |r| r[:quote] }.sort.map do |_, group|

--- a/lib/blender.rb
+++ b/lib/blender.rb
@@ -2,8 +2,17 @@
 
 require "base_converter"
 
-# Blends exchange rates from multiple providers into a single set by converting each provider's rates to a common
-# base currency and averaging rates for currencies that appear in more than one provider.
+# Blends exchange rates from multiple providers into a single set by converting
+# each provider's rates to a common base currency, then computing a
+# recency-weighted average for currencies quoted by more than one provider.
+#
+# Providers publish on different schedules, so the "latest" rate from each may
+# be from different dates. Rather than treating all dates as equal, we weight
+# each rate by how fresh it is. Rates from the last few days (the grace period)
+# carry full weight — this accommodates weekends and holidays where a 2-3 day
+# gap is normal and meaningless. Beyond the grace period, weight decays
+# exponentially so that stale rates contribute less and less without needing a
+# hard cutoff.
 class Blender
   attr_reader :rates, :base
 
@@ -12,13 +21,28 @@ class Blender
     @base = base
   end
 
+  # Days within the grace window get full weight (1.0). Beyond it, weight
+  # halves roughly every 1.4 days: day 4 ≈ 0.61, day 7 ≈ 0.14, day 10 ≈ 0.03.
+  DECAY_GRACE_DAYS = 3
+  DECAY_RATE = 0.5
+
   def blend
     rebased = rates.group_by { |r| r[:provider] }.flat_map do |_, provider_rows|
       BaseConverter.new(provider_rows, base:).convert
     end
 
+    reference_date = rebased.map { |r| r[:date] }.max
     rebased.group_by { |r| r[:quote] }.sort.map do |_, group|
-      group.max_by { |r| r[:date] }.merge(rate: group.sum { |r| r[:rate] } / group.size)
+      weighted = group.map { |r| [r, recency_weight(reference_date - r[:date])] }
+      total_weight = weighted.sum(&:last)
+      rate = weighted.sum { |r, w| r[:rate] * w } / total_weight
+      weighted.max_by { |_, w| w }.first.merge(rate:)
     end
+  end
+
+  private
+
+  def recency_weight(days_old)
+    Math.exp(-DECAY_RATE * [days_old - DECAY_GRACE_DAYS, 0].max)
   end
 end

--- a/spec/blender_spec.rb
+++ b/spec/blender_spec.rb
@@ -61,6 +61,18 @@ describe Blender do
     _(usd[:date]).must_equal(date)
   end
 
+  it "picks the most recent date regardless of input order" do
+    rates = [
+      { date: date - 1, base: "EUR", quote: "USD", rate: 1.10, provider: "BOC" },
+      { date: date, base: "EUR", quote: "USD", rate: 1.08, provider: "ECB" },
+    ]
+
+    result = Blender.new(rates, base: "EUR").blend
+    usd = result.find { |r| r[:quote] == "USD" }
+
+    _(usd[:date]).must_equal(date)
+  end
+
   it "discounts stale rates beyond the grace period" do
     rates = [
       { date: date, base: "EUR", quote: "USD", rate: 1.08, provider: "ECB" },

--- a/spec/blender_spec.rb
+++ b/spec/blender_spec.rb
@@ -48,7 +48,7 @@ describe Blender do
     _(usd[:rate]).must_be_close_to(1.08, 0.05)
   end
 
-  it "blends rates from different dates" do
+  it "blends rates equally within the grace period" do
     rates = [
       { date: date, base: "EUR", quote: "USD", rate: 1.08, provider: "ECB" },
       { date: date - 1, base: "EUR", quote: "USD", rate: 1.10, provider: "BOC" },
@@ -58,6 +58,20 @@ describe Blender do
     usd = result.find { |r| r[:quote] == "USD" }
 
     _(usd[:rate]).must_be_close_to((1.08 + 1.10) / 2.0)
-    _(usd[:date]).must_equal(date) # picks most recent date
+    _(usd[:date]).must_equal(date)
+  end
+
+  it "discounts stale rates beyond the grace period" do
+    rates = [
+      { date: date, base: "EUR", quote: "USD", rate: 1.08, provider: "ECB" },
+      { date: date - 7, base: "EUR", quote: "USD", rate: 1.20, provider: "BOC" },
+    ]
+
+    result = Blender.new(rates, base: "EUR").blend
+    usd = result.find { |r| r[:quote] == "USD" }
+
+    # 7-day-old rate has weight ~0.135 vs 1.0 for today's rate, so result skews toward 1.08
+    _(usd[:rate]).must_be_close_to(1.08, 0.02)
+    _(usd[:date]).must_equal(date)
   end
 end


### PR DESCRIPTION
## Summary

- Replace equal-weight averaging in `Blender` with exponential decay based on rate age
- Rates within a 3-day grace window (covering weekends/holidays) keep full weight
- Beyond that, weight decays at `e^(-0.5 * excess_days)` — a week-old rate contributes ~14%, two weeks ~0.4%
- Same DB query, same 14-day staleness cutoff — only the averaging step changes

## Motivation

Providers publish on different schedules. A simple average treats a week-old rate the same as today's. With recency weighting, fresh rates dominate while stale ones gracefully fade out instead of needing a hard cutoff.

| days_old | weight |
|----------|--------|
| 0-3      | 1.000  |
| 4        | 0.607  |
| 7        | 0.135  |
| 10       | 0.030  |
| 14       | 0.004  |

## Test plan

- [x] Existing blender spec updated — 1-day gap still blends equally (within grace)
- [x] New spec: 7-day-old rate heavily discounted toward fresh rate
- [ ] Verify no change for same-day blending (all weights = 1.0)
- [ ] Verify time series queries unaffected (each day blended independently)

https://claude.ai/code/session_013KifiCxCBazNW52ztERpP5