### PR TITLE
Add Norges Bank and MAS (Singapore) providers

### DIFF
--- a/bin/schedule
+++ b/bin/schedule
@@ -6,7 +6,7 @@ require "rufus-scheduler"
 scheduler = Rufus::Scheduler.new
 
 # Backfill all providers on startup (staggered to avoid thundering herd)
-["ecb", "boc", "tcmb", "nbu", "cba", "nbrb", "bob", "cbr", "nbp", "fred", "bnm", "rba", "bcra", "cbk", "boj", "imf", "nbrm", "bceao", "boi", "bccr"].each_with_index do |provider, i|
+["ecb", "boc", "tcmb", "nbu", "cba", "nbrb", "bob", "cbr", "nbp", "fred", "bnm", "rba", "bcra", "cbk", "boj", "imf", "nbrm", "bceao", "boi", "bccr", "nb", "mas"].each_with_index do |provider, i|
   scheduler.in("#{i * 2}s") do
     system("bundle exec rake #{provider}:backfill")
   end
@@ -117,6 +117,18 @@ end
 # BCCR publishes during business hours (Costa Rica, UTC-6)
 scheduler.cron("*/30 18,19,20 * * 1-5", overlap: false) do
   system("bundle exec rake bccr:backfill")
+end
+
+# Norges Bank publishes around 14:15 CET (13:15 UTC)
+# https://data.norges-bank.no/
+scheduler.cron("*/30 13,14,15 * * 1-5", overlap: false) do
+  system("bundle exec rake nb:backfill")
+end
+
+# MAS publishes daily (Singapore, UTC+8)
+# https://eservices.mas.gov.sg/statistics/
+scheduler.cron("*/30 2,3,4 * * 1-5", overlap: false) do
+  system("bundle exec rake mas:backfill")
 end
 
 scheduler.join

--- a/db/seeds/providers.json
+++ b/db/seeds/providers.json
@@ -138,5 +138,19 @@
     "description": "Daily reference exchange rate for the US dollar against the Costa Rican colon",
     "data_url": "https://sdd.bccr.fi.cr/es/IndicadoresEconomicos/Inicio/Contenedor/6",
     "terms_url": "https://sdd.bccr.fi.cr/es/IndicadoresEconomicos/Inicio/TerminosDeUso"
+  },
+  {
+    "key": "NB",
+    "name": "Norges Bank",
+    "description": "Daily exchange rates for 40+ currencies against the Norwegian krone",
+    "data_url": "https://data.norges-bank.no/",
+    "terms_url": "https://www.norges-bank.no/en/topics/Statistics/disclaimer/"
+  },
+  {
+    "key": "MAS",
+    "name": "Monetary Authority of Singapore",
+    "description": "Daily exchange rates for 15+ currencies against the Singapore dollar",
+    "data_url": "https://eservices.mas.gov.sg/statistics/",
+    "terms_url": "https://www.mas.gov.sg/terms-of-use"
   }
 ]

--- a/lib/providers/mas.rb
+++ b/lib/providers/mas.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+
+require "providers/base"
+
+module Providers
+  # Monetary Authority of Singapore daily exchange rates.
+  # Publishes ~15 currencies against SGD via a public JSON API.
+  # https://eservices.mas.gov.sg/statistics/api/v1/fin/exchange-rates/daily
+  class MAS < Base
+    BASE_URL = "https://eservices.mas.gov.sg/statistics/api/v1/fin/exchange-rates/daily"
+    EARLIEST_DATE = Date.new(2015, 1, 2)
+
+    # MAS uses flat column names like "usd_sgd", "eur_sgd", etc.
+    # Each column value is the amount of SGD per unit of foreign currency
+    # (or per 100 units for JPY, KRW, INR, etc.)
+    CURRENCY_COLUMNS = {
+      "aud_sgd" => ["AUD", 1],
+      "bgn_sgd" => ["BGN", 1],
+      "bnd_sgd" => ["BND", 1],
+      "cad_sgd" => ["CAD", 1],
+      "chf_sgd" => ["CHF", 1],
+      "cny_sgd_100" => ["CNY", 100],
+      "dkk_sgd" => ["DKK", 1],
+      "eur_sgd" => ["EUR", 1],
+      "gbp_sgd" => ["GBP", 1],
+      "hkd_sgd_100" => ["HKD", 100],
+      "idr_sgd_100" => ["IDR", 100],
+      "inr_sgd_100" => ["INR", 100],
+      "jpy_sgd_100" => ["JPY", 100],
+      "krw_sgd_100" => ["KRW", 100],
+      "lkr_sgd_100" => ["LKR", 100],
+      "myr_sgd_100" => ["MYR", 100],
+      "nok_sgd" => ["NOK", 1],
+      "nzd_sgd" => ["NZD", 1],
+      "php_sgd_100" => ["PHP", 100],
+      "qar_sgd_100" => ["QAR", 100],
+      "sar_sgd_100" => ["SAR", 100],
+      "sek_sgd" => ["SEK", 1],
+      "thb_sgd_100" => ["THB", 100],
+      "twd_sgd_100" => ["TWD", 100],
+      "usd_sgd" => ["USD", 1],
+      "vnd_sgd_100" => ["VND", 100],
+    }.freeze
+
+    class << self
+      def key = "MAS"
+      def name = "Monetary Authority of Singapore"
+      def earliest_date = EARLIEST_DATE
+    end
+
+    def fetch(since: nil, upto: nil)
+      @dataset = []
+      params = { rows: 10000, sort: "end_of_day asc" }
+      params[:between] = "[end_of_day,#{since}]" if since
+
+      url = URI(BASE_URL)
+      url.query = URI.encode_www_form(params)
+
+      response = Net::HTTP.get(url)
+      data = JSON.parse(response)
+
+      @dataset = parse(data)
+      self
+    rescue Net::OpenTimeout, Net::ReadTimeout, JSON::ParserError
+      self
+    end
+
+    def parse(data)
+      data = JSON.parse(data) if data.is_a?(String)
+      records = data.dig("result", "records") || []
+
+      records.flat_map do |record|
+        date = Date.parse(record["end_of_day"])
+
+        CURRENCY_COLUMNS.filter_map do |column, (currency, unit)|
+          value = record[column]
+          next if value.nil? || value.to_s.strip.empty?
+
+          rate = Float(value)
+          next if rate.zero?
+
+          { provider: key, date:, base: currency, quote: "SGD", rate: rate / unit }
+        rescue ArgumentError, TypeError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/providers/mas.rb
+++ b/lib/providers/mas.rb
@@ -7,23 +7,22 @@ require "providers/base"
 
 module Providers
   # Monetary Authority of Singapore daily exchange rates.
-  # Publishes ~15 currencies against SGD via a public JSON API.
-  # https://eservices.mas.gov.sg/statistics/api/v1/fin/exchange-rates/daily
+  # Publishes 21 currencies against SGD via a public JSON API (no auth required).
+  # https://eservices.mas.gov.sg/api/action/datastore/search.json
   class MAS < Base
-    BASE_URL = "https://eservices.mas.gov.sg/statistics/api/v1/fin/exchange-rates/daily"
+    BASE_URL = "https://eservices.mas.gov.sg/api/action/datastore/search.json"
+    RESOURCE_ID = "95932927-c8bc-4e7a-b484-68a66a24edfe"
     EARLIEST_DATE = Date.new(2015, 1, 2)
 
     # MAS uses flat column names like "usd_sgd", "eur_sgd", etc.
     # Each column value is the amount of SGD per unit of foreign currency
     # (or per 100 units for JPY, KRW, INR, etc.)
     CURRENCY_COLUMNS = {
+      "aed_sgd_100" => ["AED", 100],
       "aud_sgd" => ["AUD", 1],
-      "bgn_sgd" => ["BGN", 1],
-      "bnd_sgd" => ["BND", 1],
       "cad_sgd" => ["CAD", 1],
       "chf_sgd" => ["CHF", 1],
       "cny_sgd_100" => ["CNY", 100],
-      "dkk_sgd" => ["DKK", 1],
       "eur_sgd" => ["EUR", 1],
       "gbp_sgd" => ["GBP", 1],
       "hkd_sgd_100" => ["HKD", 100],
@@ -31,14 +30,11 @@ module Providers
       "inr_sgd_100" => ["INR", 100],
       "jpy_sgd_100" => ["JPY", 100],
       "krw_sgd_100" => ["KRW", 100],
-      "lkr_sgd_100" => ["LKR", 100],
       "myr_sgd_100" => ["MYR", 100],
-      "nok_sgd" => ["NOK", 1],
       "nzd_sgd" => ["NZD", 1],
       "php_sgd_100" => ["PHP", 100],
       "qar_sgd_100" => ["QAR", 100],
       "sar_sgd_100" => ["SAR", 100],
-      "sek_sgd" => ["SEK", 1],
       "thb_sgd_100" => ["THB", 100],
       "twd_sgd_100" => ["TWD", 100],
       "usd_sgd" => ["USD", 1],
@@ -53,8 +49,8 @@ module Providers
 
     def fetch(since: nil, upto: nil)
       @dataset = []
-      params = { rows: 10000, sort: "end_of_day asc" }
-      params[:between] = "[end_of_day,#{since}]" if since
+      params = { resource_id: RESOURCE_ID, limit: 10000, sort: "end_of_day asc" }
+      params["between[end_of_day]"] = "#{since},#{upto || Date.today}" if since
 
       url = URI(BASE_URL)
       url.query = URI.encode_www_form(params)

--- a/lib/providers/nb.rb
+++ b/lib/providers/nb.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "csv"
+require "net/http"
+
+require "providers/base"
+
+module Providers
+  # Norges Bank daily exchange rates. Publishes ~40 currencies against NOK.
+  # Uses the same SDMX REST API standard as ECB, with CSV output.
+  # https://data.norges-bank.no/api/data/EXR/B..NOK.SP
+  class NB < Base
+    SDMX_URL = "https://data.norges-bank.no/api/data/EXR/B..NOK.SP"
+    EARLIEST_DATE = Date.new(1999, 1, 4)
+
+    class << self
+      def key = "NB"
+      def name = "Norges Bank"
+      def earliest_date = EARLIEST_DATE
+
+      def backfill(range: 365)
+        super
+      end
+    end
+
+    def fetch(since: nil, upto: nil)
+      url = URI(SDMX_URL)
+      params = { format: "csvdata" }
+      params[:startPeriod] = since.to_s if since
+      params[:endPeriod] = upto.to_s if upto
+      url.query = URI.encode_www_form(params)
+
+      @dataset = []
+      stream_csv(url) do |row|
+        record = parse_row(row)
+        @dataset << record if record
+      end
+
+      self
+    rescue Net::OpenTimeout, Net::ReadTimeout
+      self
+    end
+
+    def parse(csv)
+      CSV.parse(csv, headers: true, liberal_parsing: true).filter_map do |row|
+        parse_row(row)
+      end
+    end
+
+    private
+
+    def parse_row(row)
+      return unless row["FREQ"] == "B"
+
+      currency = row["BASE_CUR"]
+      return unless currency&.match?(/\A[A-Z]{3}\z/)
+
+      rate = Float(row["OBS_VALUE"])
+      date = Date.parse(row["TIME_PERIOD"])
+
+      # Norges Bank quotes rates as NOK per unit of foreign currency.
+      # UNIT_MULT indicates the power-of-10 unit (e.g. 2 means per 100 units).
+      unit_mult = Integer(row["UNIT_MULT"] || "0")
+      divisor = 10**unit_mult
+
+      { provider: key, date:, base: currency, quote: "NOK", rate: rate / divisor }
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def stream_csv(url)
+      uri = URI(url)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        request = Net::HTTP::Get.new(uri)
+        http.request(request) do |response|
+          headers = nil
+          buffer = +""
+
+          response.read_body do |chunk|
+            buffer << chunk
+            while (line_end = buffer.index("\n"))
+              line = buffer.slice!(0..line_end)
+              if headers.nil?
+                headers = CSV.parse_line(line, liberal_parsing: true)
+              else
+                values = CSV.parse_line(line, liberal_parsing: true)
+                next unless values
+
+                row = CSV::Row.new(headers, values)
+                yield row
+              end
+            end
+          end
+
+          if headers && !buffer.empty?
+            values = CSV.parse_line(buffer, liberal_parsing: true)
+            yield CSV::Row.new(headers, values) if values
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -22,4 +22,6 @@ task backfill: [
   "bceao:backfill",
   "boi:backfill",
   "bccr:backfill",
+  "nb:backfill",
+  "mas:backfill",
 ]

--- a/lib/tasks/mas.rake
+++ b/lib/tasks/mas.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :mas do
+  desc "Backfill MAS rates"
+  task :backfill do
+    require "providers/mas"
+    Providers::MAS.backfill
+  end
+end

--- a/lib/tasks/nb.rake
+++ b/lib/tasks/nb.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :nb do
+  desc "Backfill Norges Bank rates"
+  task :backfill do
+    require "providers/nb"
+    Providers::NB.backfill
+  end
+end

--- a/lib/versions/v2.rb
+++ b/lib/versions/v2.rb
@@ -25,6 +25,8 @@ require "providers/nbrm"
 require "providers/bceao"
 require "providers/boi"
 require "providers/bccr"
+require "providers/nb"
+require "providers/mas"
 require "versions/v2/query"
 
 module Versions

--- a/spec/providers/mas_spec.rb
+++ b/spec/providers/mas_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "providers/mas"
+
+module Providers
+  describe MAS do
+    let(:provider) { MAS.new }
+
+    it "parses JSON response" do
+      data = {
+        "result" => {
+          "records" => [
+            {
+              "end_of_day" => "2025-03-24",
+              "usd_sgd" => "1.3456",
+              "eur_sgd" => "1.4567",
+              "jpy_sgd_100" => "0.8912",
+            },
+          ],
+        },
+      }
+
+      records = provider.parse(data)
+
+      _(records.size).must_equal(3)
+
+      usd = records.find { |r| r[:base] == "USD" }
+      _(usd[:quote]).must_equal("SGD")
+      _(usd[:rate]).must_be_close_to(1.3456)
+      _(usd[:date]).must_equal(Date.new(2025, 3, 24))
+      _(usd[:provider]).must_equal("MAS")
+
+      # JPY is per 100 units
+      jpy = records.find { |r| r[:base] == "JPY" }
+      _(jpy[:rate]).must_be_close_to(0.008912)
+    end
+
+    it "skips empty or null values" do
+      data = {
+        "result" => {
+          "records" => [
+            {
+              "end_of_day" => "2025-03-24",
+              "usd_sgd" => "1.3456",
+              "eur_sgd" => "",
+              "jpy_sgd_100" => nil,
+            },
+          ],
+        },
+      }
+
+      records = provider.parse(data)
+
+      _(records.size).must_equal(1)
+      _(records.first[:base]).must_equal("USD")
+    end
+
+    it "handles multiple dates" do
+      data = {
+        "result" => {
+          "records" => [
+            { "end_of_day" => "2025-03-24", "usd_sgd" => "1.3456" },
+            { "end_of_day" => "2025-03-25", "usd_sgd" => "1.3500" },
+          ],
+        },
+      }
+
+      records = provider.parse(data)
+
+      _(records.size).must_equal(2)
+      dates = records.map { |r| r[:date] }.uniq
+      _(dates.size).must_equal(2)
+    end
+  end
+end

--- a/spec/providers/nb_spec.rb
+++ b/spec/providers/nb_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+require "providers/nb"
+
+module Providers
+  describe NB do
+    let(:provider) { NB.new }
+
+    it "parses SDMX CSV data" do
+      csv = <<~CSV
+        FREQ,BASE_CUR,QUOTE_CUR,TENOR,TIME_PERIOD,OBS_VALUE,UNIT_MULT
+        B,USD,NOK,SP,2025-03-24,10.5432,0
+        B,EUR,NOK,SP,2025-03-24,11.4567,0
+        B,JPY,NOK,SP,2025-03-24,7.0123,2
+      CSV
+
+      records = provider.parse(csv)
+
+      _(records.size).must_equal(3)
+
+      usd = records.find { |r| r[:base] == "USD" }
+      _(usd[:quote]).must_equal("NOK")
+      _(usd[:rate]).must_be_close_to(10.5432)
+      _(usd[:date]).must_equal(Date.new(2025, 3, 24))
+      _(usd[:provider]).must_equal("NB")
+
+      # JPY has UNIT_MULT=2, so rate is per 100 units
+      jpy = records.find { |r| r[:base] == "JPY" }
+      _(jpy[:rate]).must_be_close_to(0.070123)
+    end
+
+    it "skips non-business-day rows" do
+      csv = <<~CSV
+        FREQ,BASE_CUR,QUOTE_CUR,TENOR,TIME_PERIOD,OBS_VALUE,UNIT_MULT
+        M,USD,NOK,SP,2025-03,10.5432,0
+      CSV
+
+      records = provider.parse(csv)
+      _(records).must_be_empty
+    end
+
+    it "skips invalid currency codes" do
+      csv = <<~CSV
+        FREQ,BASE_CUR,QUOTE_CUR,TENOR,TIME_PERIOD,OBS_VALUE,UNIT_MULT
+        B,US,NOK,SP,2025-03-24,10.5432,0
+      CSV
+
+      records = provider.parse(csv)
+      _(records).must_be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Norges Bank (NB)**: SDMX REST API, ~40 currencies vs NOK, no auth. Uses CSV streaming, same pattern as ECB provider. Handles UNIT_MULT for currencies quoted per 100 units.
- **MAS (Singapore)**: JSON datastore API, 21 currencies vs SGD, no auth. Flat column structure (`usd_sgd`, `jpy_sgd_100`, etc.) with unit normalization.
- Both wired into v2 API, rake tasks, scheduler cron, and seed data.

## Scheduler

- **NB**: weekdays 13:00-15:00 UTC (publishes ~14:15 CET)
- **MAS**: weekdays 02:00-04:00 UTC (Singapore business hours)

## Test plan

- [x] NB parse spec: SDMX CSV parsing, UNIT_MULT handling, frequency filtering
- [x] MAS parse spec: JSON parsing, per-100 unit handling, empty value skipping
- [ ] VCR cassettes will be auto-created on first live test run
- [ ] Verify `rake nb:backfill` and `rake mas:backfill` work against live APIs
- [ ] Verify both appear in `GET /v2/providers` after seeding

https://claude.ai/code/session_013KifiCxCBazNW52ztERpP5