### PR TITLE
Fix V2 rates to return quotes in alphabetical order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle
 coverage
 pkg
+tmp
 *.sqlite3*
 .claude/**/*.local*
 docs

--- a/lib/versions/v2/rate_query.rb
+++ b/lib/versions/v2/rate_query.rb
@@ -195,26 +195,30 @@ module Versions
           blended = blended.map { |r| r.merge(rate: r[:rate] / base_peg.rate, base:) }
         end
 
+        records = []
         emitted_quotes = Set.new
         blended.each do |r|
           next if quotes && !quotes.include?(r[:quote])
 
           emitted_quotes << r[:quote]
-          yield({ date: r[:date].to_s, base: r[:base], quote: r[:quote], rate: round(r[:rate]) })
+          records << { date: r[:date].to_s, base: r[:base], quote: r[:quote], rate: round(r[:rate]) }
         end
 
         if base_peg && (!quotes || quotes.include?(base_peg.base))
           anchor_date = blended.map { |r| r[:date] }.max
           if anchor_date && !emitted_quotes.include?(base_peg.base)
             emitted_quotes << base_peg.base
-            yield({ date: anchor_date.to_s, base:, quote: base_peg.base, rate: round(1.0 / base_peg.rate) })
+            records << { date: anchor_date.to_s, base:, quote: base_peg.base, rate: round(1.0 / base_peg.rate) }
           end
         end
 
-        expand_pegs(blended, emitted_quotes, &block)
+        collect_pegs(blended, emitted_quotes, records)
+
+        records.sort_by! { |r| r[:quote] }
+        records.each(&block)
       end
 
-      def expand_pegs(blended, emitted_quotes)
+      def collect_pegs(blended, emitted_quotes, records)
         return if providers
 
         reference_date = blended.map { |r| r[:date] }.max
@@ -237,7 +241,7 @@ module Versions
             rate = anchor[:rate] * peg.rate
           end
 
-          yield({ date: date.to_s, base:, quote: peg.quote, rate: round(rate) })
+          records << { date: date.to_s, base:, quote: peg.quote, rate: round(rate) }
         end
       end
 

--- a/lib/versions/v2/rate_query.rb
+++ b/lib/versions/v2/rate_query.rb
@@ -212,19 +212,18 @@ module Versions
           end
         end
 
-        collect_pegs(blended, emitted_quotes, records)
-
+        records.concat(pegs(blended, emitted_quotes))
         records.sort_by! { |r| r[:quote] }
         records.each(&block)
       end
 
-      def collect_pegs(blended, emitted_quotes, records)
-        return if providers
+      def pegs(blended, emitted_quotes)
+        return [] if providers
 
         reference_date = blended.map { |r| r[:date] }.max
-        return unless reference_date
+        return [] unless reference_date
 
-        Peg.all.each do |peg|
+        Peg.all.filter_map do |peg|
           next if peg.quote == base
           next if emitted_quotes.include?(peg.quote)
           next if quotes && !quotes.include?(peg.quote)
@@ -241,7 +240,7 @@ module Versions
             rate = anchor[:rate] * peg.rate
           end
 
-          records << { date: date.to_s, base:, quote: peg.quote, rate: round(rate) }
+          { date: date.to_s, base:, quote: peg.quote, rate: round(rate) }
         end
       end
 

--- a/spec/versions/v2_spec.rb
+++ b/spec/versions/v2_spec.rb
@@ -329,6 +329,15 @@ describe Versions::V2 do
     _(records.first).must_include(:rate)
   end
 
+  it "returns rates in alphabetical order by quote" do
+    get "/rates"
+
+    _(last_response).must_be(:ok?)
+    quotes = json.map { |r| r["quote"] }
+
+    _(quotes).must_equal(quotes.sort)
+  end
+
   it "excludes pegged currencies when providers filter is set" do
     get "/rates?providers=ecb"
 


### PR DESCRIPTION
Pegged currencies were appended after blended rates without sorting,
causing quotes like GGP, IMP, JEP, ANG to appear at the end instead
of in their correct alphabetical position. Collect all records
(blended + pegs) then sort by quote before yielding.

https://claude.ai/code/session_019hKCrpjTNCbKiQUyJ2zaqs