### PR TITLE
Add XOF and XAF EUR pegs

### DIFF
--- a/db/seeds/pegs.json
+++ b/db/seeds/pegs.json
@@ -142,5 +142,21 @@
     "since": "1999-01-01",
     "authority": "Banco de Cabo Verde",
     "source": "https://www.bcv.cv/pt/Supervisao/Consumidores/Servi%C3%A7os%20ao%20P%C3%BAblico/perguntasrespostasfrequentes/mercadocambial/Paginas/MercadoCambial.aspx"
+  },
+  {
+    "quote": "XAF",
+    "base": "EUR",
+    "rate": 655.957,
+    "since": "1999-01-01",
+    "authority": "Banque des États de l'Afrique Centrale",
+    "source": "https://en.wikipedia.org/wiki/Central_African_CFA_franc"
+  },
+  {
+    "quote": "XOF",
+    "base": "EUR",
+    "rate": 655.957,
+    "since": "1999-01-01",
+    "authority": "Banque Centrale des États de l'Afrique de l'Ouest",
+    "source": "https://en.wikipedia.org/wiki/West_African_CFA_franc"
   }
 ]


### PR DESCRIPTION
Both CFA francs are pegged to the euro at 655.957 since 1999-01-01,
inherited from the FRF arrangement (1 FRF = 100 CFA post-1994
devaluation) when the euro replaced the French franc.