### PR TITLE
Block SEO crawlers in robots.txt

### DIFF
--- a/lib/public/robots.txt
+++ b/lib/public/robots.txt
@@ -1,2 +1,11 @@
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: AhrefsSiteAudit
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
 User-agent: *
 Allow: /


### PR DESCRIPTION
Ahrefs crawls the CSV endpoints in parallel. Each unique query string misses the cache and can take up to 20 seconds to compute, so a parallel crawl saturates the origin and surfaces as 520, 521, and 522 errors at the Cloudflare edge.

Nothing on the API host needs search indexing. This blocks AhrefsBot, AhrefsSiteAudit, and SemrushBot while keeping the API open to everything else, including user-triggered AI fetchers like ChatGPT-User and Claude-User that respect robots.txt.