### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       TCMB_API_KEY: test
       FRED_API_KEY: test
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           bundler-cache: true
       - run: bundle exec rake
@@ -32,23 +32,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: lineofflight/frankfurter
           tags: |
@@ -59,7 +59,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Extract version from tag
         id: extract_version
         run: |
@@ -103,7 +103,7 @@ jobs:
             echo "Release ${{ steps.extract_version.outputs.version }}" > release_notes.md
           fi
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.extract_version.outputs.version }}
           name: ${{ steps.extract_version.outputs.version }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       

--- a/.github/workflows/provider-health.yml
+++ b/.github/workflows/provider-health.yml
@@ -16,8 +16,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       - run: ruby bin/provider_health.rb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi, small drive-by contribution: this pins the nine third-party actions across the three workflows to their commit shas, plus the first-party checkout ones while at it, versions kept as comments.

A tag like `@v1` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. Two spots stand out here: the Docker publish and release path (`docker/login-action`, `softprops/action-gh-release` run with your registry and release credentials), and `dependabot-auto-merge.yml`, where `dependabot/fetch-metadata` runs with `contents: write` on `pull_request_target`. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066).

Dependabot keeps working exactly as today, including the auto-merge flow: it understands sha pins with a version comment and will keep opening (and auto-merging) its bump PRs.

One heads up: if you use an Actions allowlist in the repo settings, patterns written against tags (like `owner/action@v1`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

All shas were resolved from the upstream repos and cross checked against their tags. No logic changes, only the `uses:` lines.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on main. I'll also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.