### PR TITLE
Honour peg start dates when anchoring blended rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Peg rates no longer override provider rates for dates before the peg took effect. (#603)
+
 ## [2.4.0] - 2026-09-09
 
 ### Added

--- a/lib/peg_anchor.rb
+++ b/lib/peg_anchor.rb
@@ -51,6 +51,7 @@ class PegAnchor
   def anchor_quote(row)
     peg = Peg.find(row[:quote])
     return row unless peg
+    return row if row[:date] < peg.since
 
     rate = if peg.base == @base
              peg.rate

--- a/spec/peg_anchor_spec.rb
+++ b/spec/peg_anchor_spec.rb
@@ -29,6 +29,19 @@ describe PegAnchor do
 
       _(aed[:providers]).must_equal([{ key: "ECB", rate: 3.67, excluded: true }])
     end
+
+    it "leaves blended rates untouched before the peg start date" do
+      old_date = Date.parse("2014-06-02")
+      blended = [
+        { date: old_date, base: "USD", quote: "TMT", rate: 2.85, providers: [{ key: "CBR", rate: 2.85 }] },
+      ]
+
+      result = PegAnchor.apply(blended, base: "USD")
+      tmt = result.find { |r| r[:quote] == "TMT" }
+
+      _(tmt[:rate]).must_equal(2.85)
+      _(tmt[:providers]).must_equal([{ key: "CBR", rate: 2.85 }])
+    end
   end
 
   describe "cross-base peg substitution" do


### PR DESCRIPTION
`PegAnchor#anchor_quote` substitutes a peg's rate for every date, including dates before the peg's own `since`. Correct provider history is discarded and every contributing provider marked `excluded`. `synthesized_pegs` already guards on `since`; the override path did not.

## What changed

- `lib/peg_anchor.rb`: return the row untouched when `row[:date] < peg.since`. Compared per row rather than against the batch-level `reference_date`, so a range spanning a `since` boundary stays correct on both sides.
- `spec/peg_anchor_spec.rb`: regression test covering the pre-`since` case.

## Evidence

Turkmenistan devalued the manat from 2.85 to 3.5 on 2015-01-01, which is exactly `db/seeds/pegs/tmt.json`'s `since`. Rates from well before that date come back as 3.5 today:

```bash
curl -s "https://api.frankfurter.dev/v2/rates?base=USD&quotes=TMT&date=2014-06-02&expand=providers"
```

```json
[{"date":"2014-06-02","base":"USD","quote":"TMT","rate":3.5,
  "providers":[
    {"key":"BDI","date":"2014-06-02","rate":2.85,  "excluded":true},
    {"key":"CBR","date":"2014-05-30","rate":2.85,  "excluded":true},
    {"key":"LB", "date":"2014-06-02","rate":2.8503,"excluded":true},
    {"key":"NBG","date":"2014-06-02","rate":2.85,  "excluded":true}
  ]}]
```

Six providers independently report ~2.85 and all six are excluded — a ~23% error with the correct value present in the payload. The new test fails on `main` with `Expected: 2.85 / Actual: 3.5` and passes with the guard.

The other 20 pegs move by far less at their boundary (BHD ~0.26%, QAR ~0.03%, AED ~0.02%), because those currencies already sat at their peg beforehand.

## Note

This changes stored output, so `blended_rates` needs a `rake blend:rebuild` to pick it up and `rake blend:parity` will flag the diff.

Tests: `APP_ENV=test bundle exec rake` — 1254 runs, 0 failures, 0 errors, RuboCop clean.

Fixes #603